### PR TITLE
Add backend python integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ pnpm install
 pnpm dev
 ```
 
+## Python 連携
+
+バックエンド処理を Python スクリプトで実行する簡単な API を追加しました。`app/api/python` に POST すると、`python/hello.py` が呼び出され JSON を返します。
+
+## CSV データ
+
+`data` ディレクトリに CSV ファイルを置くと、`/api/csv/{ファイル名}` で内容を JSON
+として取得できます。サンプルとして `data/sample.csv` を同梱しています。
+
 ## ライセンス
 
 MIT 

--- a/app/api/csv/[file]/route.ts
+++ b/app/api/csv/[file]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { spawn } from 'child_process'
+import path from 'path'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { file: string } }
+) {
+  const filename = params.file
+  return new Promise<NextResponse>((resolve) => {
+    const csvPath = path.join(process.cwd(), 'data', filename)
+    const py = spawn('python3', ['python/read_csv.py', csvPath])
+    let output = ''
+    let error = ''
+
+    py.stdout.on('data', (data) => {
+      output += data
+    })
+
+    py.stderr.on('data', (data) => {
+      error += data
+    })
+
+    py.on('close', (code) => {
+      if (code !== 0 || error) {
+        resolve(
+          NextResponse.json(
+            { error: error || `Python exited with code ${code}` },
+            { status: 500 }
+          )
+        )
+      } else {
+        try {
+          const result = JSON.parse(output)
+          resolve(NextResponse.json(result))
+        } catch (e) {
+          resolve(
+            NextResponse.json(
+              { error: 'Invalid JSON from Python' },
+              { status: 500 }
+            )
+          )
+        }
+      }
+    })
+  })
+}

--- a/app/api/python/route.ts
+++ b/app/api/python/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { spawn } from 'child_process'
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null)
+
+  return new Promise<NextResponse>((resolve) => {
+    const py = spawn('python3', ['python/hello.py'])
+    let output = ''
+    let error = ''
+
+    py.stdout.on('data', (data) => {
+      output += data
+    })
+
+    py.stderr.on('data', (data) => {
+      error += data
+    })
+
+    py.on('close', (code) => {
+      if (code !== 0 || error) {
+        resolve(NextResponse.json({ error: error || `Python exited with code ${code}` }, { status: 500 }))
+      } else {
+        try {
+          const result = JSON.parse(output)
+          resolve(NextResponse.json(result))
+        } catch (e) {
+          resolve(NextResponse.json({ error: 'Invalid JSON from Python' }, { status: 500 }))
+        }
+      }
+    })
+
+    py.stdin.write(JSON.stringify(body))
+    py.stdin.end()
+  })
+}

--- a/data/sample.csv
+++ b/data/sample.csv
@@ -1,0 +1,3 @@
+name,value
+foo,1
+bar,2

--- a/python/hello.py
+++ b/python/hello.py
@@ -1,0 +1,15 @@
+import sys, json
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        data = None
+    result = {
+        'received': data,
+        'message': 'Hello from Python'
+    }
+    json.dump(result, sys.stdout)
+
+if __name__ == '__main__':
+    main()

--- a/python/read_csv.py
+++ b/python/read_csv.py
@@ -1,0 +1,26 @@
+import sys, csv, json, os
+
+
+def read_csv(path: str):
+    rows = []
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(row)
+    return rows
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({'error': 'Missing CSV path'}))
+        return
+    csv_path = sys.argv[1]
+    if not os.path.isfile(csv_path):
+        print(json.dumps({'error': f"File not found: {csv_path}"}))
+        return
+    rows = read_csv(csv_path)
+    json.dump({'rows': rows}, sys.stdout)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add example Python script for backend processing
- expose `/api/python` route that invokes the Python script
- document Python API usage in README
- add CSV data directory and example
- create Python script and API route to serve CSV contents

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f4490ae08326973e20ac32353ada